### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Deploy Python app to Azure Web App
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/m-lifelog/flask-azure-app/security/code-scanning/1](https://github.com/m-lifelog/flask-azure-app/security/code-scanning/1)

To fix the problem, you should add a `permissions` block to the workflow. The best way is to add it at the root level, so it applies to all jobs unless overridden. For a deployment workflow like this, the minimal required permission is usually `contents: read`, which allows the workflow to read the repository contents. If the workflow needs to create or update pull requests, issues, or other resources, you can add those permissions as needed. In this case, since the workflow only checks out code and deploys to Azure, `contents: read` is sufficient. The change should be made at the top of the `.github/workflows/deploy.yml` file, after the `name:` block and before the `on:` block.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
